### PR TITLE
[T-9515][16.0][IMP] l10n_es_genci_sale: Improve GENCI line synchronization on sale orders

### DIFF
--- a/l10n_es_genci_sale/models/sale_order.py
+++ b/l10n_es_genci_sale/models/sale_order.py
@@ -62,9 +62,8 @@ class SaleOrder(models.Model):
 
     def manage_genci_order_lines(self):
         genci_product = self.env.ref("l10n_es_genci_account.product_genci_service")
+        sol_model = self.env["sale.order.line"]
         for order in self:
-            order._remove_genci_lines()
-            # Decide whether GENCI applies
             if order.fiscal_position_id:
                 apply_genci = order.fiscal_position_id.genci_subject
             else:
@@ -78,22 +77,9 @@ class SaleOrder(models.Model):
                 apply_genci = order.is_genci
             if not apply_genci:
                 continue
-            source_lines = order.order_line.filtered(
-                lambda l: l.product_id.genci_subject == "yes"
-                and l.product_id.genci_rule_id
-            )
-            if not source_lines:
+            vals_list = sol_model._get_genci_vals(order, genci_product)
+            if not vals_list:
                 continue
-            rule_quantities = {}
-            for line in source_lines:
-                rule = line.product_id.genci_rule_id
-                rule_quantities.setdefault(rule, 0.0)
-                # GENCI amount is computed per sold unit.
-                # No UoM conversion is applied intentionally.
-                rule_quantities[rule] += line.product_uom_qty
-                line.genci_amount = line.product_uom_qty * rule.unit_price
-            last_seq = max(order.order_line.mapped("sequence") or [0])
-            seq = last_seq
             genci_account = (
                 genci_product.property_account_income_id
                 or genci_product.categ_id.property_account_income_categ_id
@@ -103,41 +89,7 @@ class SaleOrder(models.Model):
                     _("No accounting account defined for GENCI product %s")
                     % genci_product.display_name
                 )
-            vals_list = []
-            for rule, qty in rule_quantities.items():
-                seq += 1
-                vals_list.append(
-                    order._prepare_genci_line_vals(
-                        genci_product=genci_product,
-                        rule=rule,
-                        qty=qty,
-                        sequence=seq,
-                    )
-                )
-            if vals_list:
-                sol_model = self.env["sale.order.line"]
-                for vals in vals_list:
-                    try:
-                        sol_model.create(vals)
-                    except Exception:
-                        product = self.env["product.product"].browse(
-                            vals.get("product_id")
-                        )
-                        raise UserError(
-                            _(
-                                "GENCI line could not be created.\n\n"
-                                "Sale Order: %(order)s\n"
-                                "Product: %(product)s\n"
-                                "GENCI Rule: %(rule)s\n\n"
-                                "Please check the configuration of the GENCI "
-                                "product and its accounting accounts."
-                            )
-                            % {
-                                "order": order.name or order.id,
-                                "product": product.display_name,
-                                "rule": vals.get("name"),
-                            }
-                        ) from None
+            sol_model._sync_genci_lines(order, genci_product)
 
     def _prepare_genci_line_vals(self, genci_product, rule, qty, sequence):
         self.ensure_one()
@@ -153,10 +105,10 @@ class SaleOrder(models.Model):
         }
 
     def _remove_genci_lines(self):
-        genci_product = self.env.ref(
-            "l10n_es_genci_account.product_genci_service",
-        )
-        self.order_line.filtered(lambda l: l.product_id == genci_product).unlink()
+        genci_product = self.env.ref("l10n_es_genci_account.product_genci_service")
+        self.order_line.filtered(lambda l: l.product_id == genci_product).with_context(
+            avoid_line_recursion=True
+        ).unlink()
 
     def apply_genci(self):
         draft_orders = self.filtered(lambda o: o.state == "draft" and o.is_genci)
@@ -165,14 +117,15 @@ class SaleOrder(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        # Auto-enable GENCI based on partner configuration
         partner_model = self.env["res.partner"]
         for vals in filter(lambda v: v.get("partner_id"), vals_list):
             partner = partner_model.browse(vals["partner_id"]).exists()
-            # Enable GENCI only if the user did not explicitly set is_genci
             if partner and partner.genci_subject and "is_genci" not in vals:
                 vals["is_genci"] = True
-        orders = super().create(vals_list)
+        orders = super(SaleOrder, self.with_context(avoid_line_recursion=True)).create(
+            vals_list
+        )
+        orders = orders.with_context(avoid_line_recursion=False)
         orders.apply_genci()
         return orders
 
@@ -181,22 +134,25 @@ class SaleOrder(models.Model):
         is_genci_changed = "is_genci" in vals
         res = super().write(vals)
         for order in self:
-            # Auto-enable GENCI if partner changes to one subject to GENCI,
-            # unless the user manually set is_genci in the same write
             if (
                 partner_changed
                 and order.partner_id.genci_subject
                 and not is_genci_changed
             ):
                 order.is_genci = True
-            # If GENCI is manually disabled → remove all GENCI lines
             if is_genci_changed and not order.is_genci:
                 order._remove_genci_lines()
-        # Recompute GENCI lines when relevant fields change
-        if partner_changed or is_genci_changed or "order_line" in vals:
+        if (
+            partner_changed or is_genci_changed or "order_line" in vals
+        ) and not self.env.context.get("avoid_recursion"):
             draft_orders = self.filtered(lambda o: o.state == "draft" and o.is_genci)
             if draft_orders:
-                draft_orders.with_context(
-                    avoid_recursion=True
-                ).manage_genci_order_lines()
+                genci_product = self.env.ref(
+                    "l10n_es_genci_account.product_genci_service",
+                    raise_if_not_found=False,
+                )
+                self.env["sale.order.line"]._sync_genci_lines(
+                    draft_orders,
+                    genci_product,
+                )
         return res

--- a/l10n_es_genci_sale/models/sale_order_line.py
+++ b/l10n_es_genci_sale/models/sale_order_line.py
@@ -1,6 +1,6 @@
 # Copyright 2025 Ángel Rivas <angel.rivas@sygel.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
@@ -37,4 +37,124 @@ class SaleOrderLine(models.Model):
                 )
                 billed_qty = sum(invoice_product_lines.mapped("quantity"))
                 line.qty_invoiced = min(billed_qty, line.product_uom_qty)
+        return res
+
+    def _get_genci_vals(self, order, genci_product):
+        vals_list = []
+        source_lines = order.order_line.filtered(
+            lambda l: l.product_id != genci_product
+            and l.product_id.genci_subject == "yes"
+            and l.product_id.genci_rule_id
+        )
+        if source_lines:
+            rule_quantities = {}
+            for line in source_lines:
+                rule = line.product_id.genci_rule_id
+                rule_quantities.setdefault(rule, 0.0)
+                rule_quantities[rule] += line.product_uom_qty
+                line.genci_amount = line.product_uom_qty * rule.unit_price
+
+            last_seq = max(order.order_line.mapped("sequence") or [0])
+            seq = last_seq
+
+            for rule, qty in rule_quantities.items():
+                seq += 1
+                vals_list.append(
+                    order._prepare_genci_line_vals(
+                        genci_product=genci_product,
+                        rule=rule,
+                        qty=qty,
+                        sequence=seq,
+                    )
+                )
+        return vals_list
+
+    def _sync_genci_lines(self, orders, genci_product):
+        for order in orders:
+            expected_vals = self._get_genci_vals(order, genci_product)
+            existing_lines = order.order_line.filtered(
+                lambda l: l.product_id == genci_product
+            )
+            duplicated_lines = self.env["sale.order.line"]
+            seen_names = set()
+            for line in existing_lines:
+                if line.name in seen_names:
+                    duplicated_lines |= line
+                else:
+                    seen_names.add(line.name)
+            if duplicated_lines:
+                duplicated_lines.with_context(avoid_line_recursion=True).unlink()
+                existing_lines -= duplicated_lines
+            existing_by_name = {line.name: line for line in existing_lines}
+            expected_by_name = {vals["name"]: vals for vals in expected_vals}
+            for name, vals in expected_by_name.items():
+                if name in existing_by_name:
+                    existing_by_name[name].with_context(
+                        avoid_line_recursion=True
+                    ).write(
+                        {
+                            "product_uom_qty": vals["product_uom_qty"],
+                            "price_unit": vals["price_unit"],
+                            "purchase_price": vals["purchase_price"],
+                            "sequence": vals["sequence"],
+                            "genci_amount": vals["genci_amount"],
+                        }
+                    )
+                else:
+                    self.with_context(avoid_line_recursion=True).create(vals)
+            for name, line in existing_by_name.items():
+                if name not in expected_by_name:
+                    line.with_context(avoid_line_recursion=True).unlink()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super().create(vals_list)
+        if not self.env.context.get("avoid_line_recursion"):
+            genci_product = self.env.ref(
+                "l10n_es_genci_account.product_genci_service",
+                raise_if_not_found=False,
+            )
+            orders = (
+                lines.filtered(lambda l: l.product_id != genci_product)
+                .mapped("order_id")
+                .filtered(lambda o: o.state in ["draft", "sent"] and o.is_genci)
+            )
+            self._sync_genci_lines(orders, genci_product)
+        return lines
+
+    def write(self, vals):
+        orders_before = self.mapped("order_id")
+        res = super().write(vals)
+        if not self.env.context.get("avoid_line_recursion") and any(
+            f in vals for f in ["product_id", "product_uom_qty", "order_id"]
+        ):
+            genci_product = self.env.ref(
+                "l10n_es_genci_account.product_genci_service",
+                raise_if_not_found=False,
+            )
+            orders = (
+                orders_before
+                | self.filtered(lambda l: l.product_id != genci_product).mapped(
+                    "order_id"
+                )
+            ).filtered(lambda o: o.state in ["draft", "sent"] and o.is_genci)
+            self._sync_genci_lines(orders, genci_product)
+        return res
+
+    def unlink(self):
+        orders = self.filtered(
+            lambda l: l.product_id
+            and l.product_id.genci_subject == "yes"
+            and l.product_id.genci_rule_id
+        ).mapped("order_id")
+        res = super().unlink()
+        if not self.env.context.get("avoid_line_recursion"):
+            genci_product = self.env.ref(
+                "l10n_es_genci_account.product_genci_service",
+                raise_if_not_found=False,
+            )
+            orders = orders.filtered(
+                lambda o: o.state in ["draft", "sent"] and o.is_genci
+            )
+            self._sync_genci_lines(orders, genci_product)
         return res

--- a/l10n_es_genci_sale/tests/test_l10n_es_genci_sale.py
+++ b/l10n_es_genci_sale/tests/test_l10n_es_genci_sale.py
@@ -326,3 +326,117 @@ class TestL10nEsGenciSale(TransactionCase):
             expected_amount,
             "The genci_amount of the original line was not calculated correctly.",
         )
+
+    def test_sale_order_line_create_syncs_genci_lines(self):
+        genci_service = self.env.ref("l10n_es_genci_account.product_genci_service")
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "date_order": date.today(),
+                "is_genci": True,
+            }
+        )
+
+        self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 2,
+                "price_unit": 10.0,
+            }
+        )
+
+        genci_lines = order.order_line.filtered(lambda l: l.product_id == genci_service)
+        self.assertEqual(len(genci_lines), 1)
+        self.assertEqual(genci_lines.product_uom_qty, 2)
+        self.assertEqual(genci_lines.price_unit, self.rule_valid.unit_price)
+
+    def test_sale_order_line_write_updates_genci_lines(self):
+        genci_service = self.env.ref("l10n_es_genci_account.product_genci_service")
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "date_order": date.today(),
+                "is_genci": True,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 10.0,
+                        },
+                    )
+                ],
+            }
+        )
+        product_line = order.order_line.filtered(lambda l: l.product_id == self.product)
+        product_line.write({"product_uom_qty": 3})
+        genci_lines = order.order_line.filtered(lambda l: l.product_id == genci_service)
+        self.assertEqual(len(genci_lines), 1)
+        self.assertEqual(genci_lines.product_uom_qty, 3)
+        self.assertEqual(product_line.genci_amount, 30.0)
+
+    def test_sale_order_line_unlink_removes_genci_line(self):
+        genci_service = self.env.ref("l10n_es_genci_account.product_genci_service")
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "date_order": date.today(),
+                "is_genci": True,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 10.0,
+                        },
+                    )
+                ],
+            }
+        )
+        product_line = order.order_line.filtered(lambda l: l.product_id == self.product)
+        product_line.unlink()
+        genci_lines = order.order_line.filtered(lambda l: l.product_id == genci_service)
+        self.assertFalse(
+            genci_lines,
+            "GENCI line should be removed when the source line is deleted.",
+        )
+
+    def test_sale_order_line_write_does_not_duplicate_genci_lines(self):
+        genci_service = self.env.ref("l10n_es_genci_account.product_genci_service")
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "date_order": date.today(),
+                "is_genci": True,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 10.0,
+                        },
+                    )
+                ],
+            }
+        )
+        product_line = order.order_line.filtered(lambda l: l.product_id == self.product)
+        product_line.write({"product_uom_qty": 2})
+        product_line.write({"product_uom_qty": 4})
+        genci_lines = order.order_line.filtered(lambda l: l.product_id == genci_service)
+        self.assertEqual(
+            len(genci_lines),
+            1,
+            "GENCI line should be updated, not duplicated.",
+        )
+        self.assertEqual(genci_lines.product_uom_qty, 4)


### PR DESCRIPTION
@HaraldPanten @Jaimermaccione 

- Improved GENCI sale order line management to correctly handle products added, updated, or removed through the `sale_order_product_recommendation` wizard. Centralized GENCI line calculation and synchronization in `sale.order.line` through `_get_genci_vals()` and `_sync_genci_lines()`, extending `create()`, `write()`, and `unlink()` to keep GENCI lines consistent across all sale order flows.